### PR TITLE
Change org-link face in Tomorrow theme

### DIFF
--- a/themes/color-theme-tomorrow.el
+++ b/themes/color-theme-tomorrow.el
@@ -355,7 +355,7 @@ names to which it refers are bound."
      (org-footnote ((t (:foreground ,aqua))))
      (org-formula ((t (:foreground ,red))))
      (org-hide ((t (:foreground ,current-line))))
-     (org-link ((t (:foreground ,blue))))
+     (org-link ((t (:foreground ,blue :underline t))))
      (org-scheduled ((t (:foreground ,green))))
      (org-scheduled-previously ((t (:foreground ,orange))))
      (org-scheduled-today ((t (:foreground ,green))))


### PR DESCRIPTION
Just a small change in the Tomorrow theme to make org-mode link underlined, matching other modes.