### PR TITLE
Make the fringe refresh on commit

### DIFF
--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -52,7 +52,8 @@ These are restored by `exordium-magit-quit-session'.")
               exordium-magit-log-buffer
               exordium-magit-log
               exordium--magit-fullscreen
-              exordium-projectile-add-known-project)
+              exordium-projectile-add-known-project
+              exordium-refresh-git-gutter-all-buffers)
 
   :defines (magit-last-seen-setup-instructions)
   :init
@@ -150,7 +151,19 @@ with `exordium-magit-quit-session'."
     (when (fboundp 'magit-status-internal) ;; check just like in `projectile-vc'
       (advice-add 'magit-status-internal :around #'exordium--magit-fullscreen)))
 
-  (advice-add 'magit-clone-regular :after #'exordium-projectile-add-known-project))
+  (advice-add 'magit-clone-regular :after #'exordium-projectile-add-known-project)
+
+  ;; Refresh git-gutter after magit operations
+  (when exordium-git-gutter
+    (defun exordium-refresh-git-gutter-all-buffers ()
+      "Refresh git-gutter in all buffers after magit operations."
+      (dolist (buffer (buffer-list))
+        (with-current-buffer buffer
+          (when (and (bound-and-true-p git-gutter-mode)
+                     (buffer-file-name))
+            (git-gutter)))))
+
+    (add-hook 'magit-post-refresh-hook #'exordium-refresh-git-gutter-all-buffers)))
 
 
 ;; SMerge Dispatch


### PR DESCRIPTION
If you use the `exordium-git-gutter` feature to display the git changes (lines changed, added, removed) in the fringe, Exordium refreshes the fringe when you save the current buffer. It does not however refreshes the fringe automatically when the user commits a changes via magit. The only way I know to do that is to switch to another buffer and then come back to your current buffer, which is annoying.

This PR fixes the problem. You can:
* Make changes in the current buffer, save the file. The fringe displays what you changed.
* Commit the changes via magit. Quit the magit buffer to come back to your file. Now the fringe is cleared.