### PR TITLE
CI update (April 2026)

### DIFF
--- a/.ci/batch-flycheck.el
+++ b/.ci/batch-flycheck.el
@@ -18,11 +18,10 @@ SOURCE is the source file used to compile with
     (goto-char (point-min))
     (let (matches
           (not-errors
-           (list
-            (rx "the function ‘exordium--require-load’ might not be defined at runtime.")
-            (rx "the function `exordium--require-load' might not be defined at runtime.")
-            (rx "‘package-vc-install-from-checkout’ is an obsolete function (as of 31.1); use the User Lisp directory instead.")
-            (rx "`package-vc-install-from-checkout' is an obsolete function (as of 31.1); use the User Lisp directory instead."))))
+           (rx-let ((quoted (func) (seq (or "‘" "`") func (or "’" "'"))))
+             (list
+              (rx "the function " (quoted "exordium--require-load") " might not be defined at runtime.")
+              (rx (quoted "package-vc-install-from-checkout") " is an obsolete function (as of 31.1); " (one-or-more not-newline))))))
       (when-let* (((re-search-forward (rx-to-string `(seq " -- " ,source line-end))
                                       nil t))
                   (pattern (rx-to-string
@@ -93,10 +92,7 @@ SOURCE is the source file used to compile with
             (setq command-line-args-left (cdr command-line-args-left))))
       (setq command-line-args-left nil)
       (when (< 0 number-of-errors)
-        (message "\n===Errors and Warnings===\n%s\n"
-                 (mapconcat #'identity errors "\n"))
-        (let ((msg (format "There are %s flycheck errors!" number-of-errors)))
-          (error msg))))))
+        (signal 'error errors)))))
 
 (provide 'batch-flycheck)
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,6 @@ jobs:
         os:
           - macos-latest
         emacs_version:
-          - 29.4
           - 30.1
           - snapshot
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
           - 29.3
           - 29.4
           - 30.1
+          - 30.2
           - release-snapshot
           - snapshot
     steps:
@@ -71,26 +72,26 @@ jobs:
 
       - name: 'Checkout checkdoc-batch'
         uses: actions/checkout@v4
-        if: contains(fromJSON('["29.4", "30.1", "snapshot", "release-snapshot"]'), matrix.emacs_version)
+        if: contains(fromJSON('["29.4", "30.1", "30.2", "snapshot", "release-snapshot"]'), matrix.emacs_version)
         with:
           repository: 'pkryger/ckeckdoc-batch.el'
           path: .emacs.d/checkdoc-batch
 
       - name: 'Lint: checkdoc'
-        if: contains(fromJSON('["29.4", "30.1", "snapshot", "release-snapshot"]'), matrix.emacs_version)
+        if: contains(fromJSON('["29.4", "30.1", "30.2", "snapshot", "release-snapshot"]'), matrix.emacs_version)
         run: '"${HOME}/.emacs.d/.ci/batch-checkdoc.sh"'
 
       - name: 'Lint: compilation' # Close to the end, to let other builds escape errors
                                   # caused by compilation shenanigans
-        if: contains(fromJSON('["30.1", "snapshot", "release-snapshot"]'), matrix.emacs_version)
+        if: contains(fromJSON('["30.1", "30.2", "snapshot", "release-snapshot"]'), matrix.emacs_version)
         run: '"${HOME}/.emacs.d/.ci/batch-byte-compile.sh"'
 
       - name: 'Lint: flycheck' # After compilation that should install all packages
-        if: contains(fromJSON('["30.1", "snapshot", "release-snapshot"]'), matrix.emacs_version)
+        if: contains(fromJSON('["30.1", "30.2", "snapshot", "release-snapshot"]'), matrix.emacs_version)
         run: '"${HOME}/.emacs.d/.ci/batch-flycheck.sh"'
 
       - name: 'Lint: relint'
-        if: contains(fromJSON('["29.4", "30.1", "snapshot", "release-snapshot"]'), matrix.emacs_version)
+        if: contains(fromJSON('["29.4", "30.1", "30.2", "snapshot", "release-snapshot"]'), matrix.emacs_version)
         run: '"${HOME}/.emacs.d/.ci/batch-relint.sh"'
 
   pkryger-taps:
@@ -102,7 +103,7 @@ jobs:
         os:
           - macos-latest
         emacs_version:
-          - 30.1
+          - 30.2
           - snapshot
     steps:
       - uses: purcell/setup-emacs@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         emacs_version:
-          - 28.1
           - 28.2
           - 29.1
           - 29.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,11 +82,11 @@ jobs:
 
       - name: 'Lint: compilation' # Close to the end, to let other builds escape errors
                                   # caused by compilation shenanigans
-        if: contains(fromJSON('["29.4", "30.1", "snapshot", "release-snapshot"]'), matrix.emacs_version)
+        if: contains(fromJSON('["30.1", "snapshot", "release-snapshot"]'), matrix.emacs_version)
         run: '"${HOME}/.emacs.d/.ci/batch-byte-compile.sh"'
 
       - name: 'Lint: flycheck' # After compilation that should install all packages
-        if: contains(fromJSON('["29.4", "30.1", "snapshot", "release-snapshot"]'), matrix.emacs_version)
+        if: contains(fromJSON('["30.1", "snapshot", "release-snapshot"]'), matrix.emacs_version)
         run: '"${HOME}/.emacs.d/.ci/batch-flycheck.sh"'
 
       - name: 'Lint: relint'

--- a/init.el
+++ b/init.el
@@ -13,7 +13,7 @@
 ;; the startup time.
 (setq gc-cons-threshold 100000000)
 
-(let ((min-version "28"))
+(let ((min-version "28.2"))
   (when (version< emacs-version min-version)
     (error "This config requires at least Emacs-%s, but you're running %s"
            min-version emacs-version)))

--- a/modules/init-help.el
+++ b/modules/init-help.el
@@ -155,7 +155,7 @@ Otherwise pop to buffer (presumably in a new window)."
                  (cons fun #'exordium--helm-helpful-completing-read))))
 
 
-(when (version< "29" emacs-version) ;; Since Emacs-29
+(when (version< "30" emacs-version) ;; Since Emacs-30
 
 (use-package casual
   :defer t

--- a/modules/init-help.el
+++ b/modules/init-help.el
@@ -219,6 +219,9 @@ Otherwise pop to buffer (presumably in a new window)."
            ("]" . #'ibuffer-forward-filter-group)
            ("$" . #'ibuffer-toggle-filter-group)))
   (use-package info
+    :autoload (Info-search
+               Info-history-forward
+               Info-history-back)
     :ensure nil
     :defer t
     :bind (:map Info-mode-map

--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -40,7 +40,8 @@
 ;;                directly to the word.  Note that the codes it generates are
 ;;                optimized for touch-type.
 ;;
-;; M-Q            `unfill-paragraph': the opposite of M-q.
+;; M-Q            `unfill-paragraph' or `exordium-unfill-paragraph'
+;;                (until Emacs 31): the opposite of M-q.
 ;;
 ;; Functions:
 ;;
@@ -401,7 +402,7 @@ buffer."
 
 ;;; Miscellaneous
 
-(defun unfill-paragraph (&optional region)
+(defun exordium-unfill-paragraph (&optional region)
   "Take a multi-line paragraph and make it into a single line of text.
 REGION is t when called interactively and is passed to
 `fill-paragraph', which see."
@@ -411,7 +412,9 @@ REGION is t when called interactively and is passed to
         (emacs-lisp-docstring-fill-column t))
     (fill-paragraph nil region)))
 
-(bind-key "M-S-q" #'unfill-paragraph)
+(bind-key "M-S-q" (if (fboundp 'unfill-paragraph)
+                      #'unfill-paragraph
+                    #'exordium-unfill-paragraph))
 
 
 ;;; Config management


### PR DESCRIPTION
A few assorted fixes to make CI pass.

## ci: Add Emacs 30.2 to build matrix

## ci(flycheck): Simplify errors reporting and filtering

## fix(help): Suppress warnings for info functions

## feat(util)!: Use built-in unfill-paragraph since Emacs 31

BREAKING CHANGE: Rename `unfill-paragraph` to `exordium-unfill-paragraph`.

BREAKING CHANGE: Use built-in `unfill-paragraph` for default keybinding when
  available (since Emacs 31).

## ci: Don't compile on Emacs 29.4

Compilation requires all packages to be installable, which is not true since
casual dropped support for Emacs 29.

## feat!: Remove support for Emacs 28.1

Org-mode served on MELPA requires at least Emacs 28.2 and disabling it seems
like more effort than it is worth (assuming support for Emacs 28 will be
removed in near future).

BREAKING CHANGE: Remove support for Emacs 28.1

## ci(pkryger/taps): Remove Emacs 29 from CI

## fix(help)!: Casual requires at least Emacs 30

BREAKING CHANGE: Casual is not available on Emacs 29 and earlier