### PR TITLE
Make comment delimiters appear the same as comments

### DIFF
--- a/themes/color-theme-catppuccin.el
+++ b/themes/color-theme-catppuccin.el
@@ -348,7 +348,7 @@ names to which it refers are bound."
      (font-lock-comment-face ((t ,(if exordium-catppuccin-italic-comments
                                       `(:inherit shadow :slant italic)
                                     `(:inherit shadow)))))
-     (font-lock-comment-delimiter-face ((t (:inherit shaddow))))
+     (font-lock-comment-delimiter-face ((t (:inherit font-lock-comment-face))))
      (font-lock-constant-face ((t (:foreground ,peach))))
      (font-lock-doc-face ((t (:inherit font-lock-comment-face))))
      (font-lock-escape-face ((t (:foreground ,pink))))


### PR DESCRIPTION
This fixes a presentation bug in the Cappuccin theme and makes it on par with the other themes. 1-line change.